### PR TITLE
Fix GitHub link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ social:
   #   desc:         Follow me on twitter
 
   - icon:         github
-    url:          https://github.com/curveballjs
+    url:          https://github.com/curveballjs/core
     desc:         Fork me on github
 
   - icon:         feed

--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ social:
   #   desc:         Follow me on twitter
 
   - icon:         github
-    url:          https://github.com/curveballjs/core
+    url:          https://github.com/curveball/core
     desc:         Fork me on github
 
   - icon:         feed


### PR DESCRIPTION
https://github.com/curveballjs results in a 404. Link to core repository instead.