### PR TITLE
Manual sorting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,12 +57,6 @@ collections_dir: collections
 collections:
   getting-started:
     output: true
-    order: 
-    - basics.md
-    - aws-lamdba.md
-    - azure.md
-    - bun.md
-    - node.md
   middleware:
     output: true
   api:

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -2,19 +2,35 @@
 layout: default
 menu:
   - title:      Getting Started
-    url_base:   /getting-started
+    url_base:   /docs/getting-started
     collection: getting-started
+    collection_items: 
+    - title: Introduction
+      url: basics
+
+    - title: Node
+      url: node
+
+    - title: Bun
+      url: bun
+      badge: new
+
+    - title: AWS Lambda
+      url: aws-lambda
+
+    - title: Azure
+      url: azure
 
   - title:       API
-    url_base:    /API
+    url_base:    /docs/api
     collection:  api
 
   - title:      Middleware
-    url_base:   /middleware
+    url_base:   /docs/middleware
     collection: middleware
 
   - title:      Examples
-    url_base:   /examples
+    url_base:   /docs/examples
     collection: examples
 ---
 
@@ -34,11 +50,28 @@ menu:
 						<summary>{{ item.title }}</summary>
 						<div>
 							<ul>
-							{% for collection-item in site[item.collection] %}
+							<!-- 
+								define collection_items inside a `menu` item 
+								in the front matter to manually sort the 
+								collection menu items
+							--> 
+							{% if item.collection_items %}
+								{% for collection-item in item.items %}
 								<li {% if collection-item.badge  %} data-badge={{collection-item.badge}} {% endif %}>
-									<a href="{{ collection-item.url }}" {% if page.url == collection-item.permalink %} class="active" {% endif %}>{{ collection-item.title }}</a>
+									<a href="{{ item.url_base }}/{{ collection-item.url }}" {% if page.url == item.url %} class="active" {% endif %}>{{ collection-item.title }}</a>
 								</li>
-							{% endfor %}
+								{% endfor %}
+							<!--
+								otherwise, look in the collections folder 
+								and use default sort
+							-->
+							{% else %}
+								{% for collection-item in site[item.collection] %}
+									<li {% if collection-item.badge  %} data-badge={{collection-item.badge}} {% endif %}>
+										<a href="{{ collection-item.url }}" {% if page.url == collection-item.permalink %} class="active" {% endif %}>{{ collection-item.title }}</a>
+									</li>
+								{% endfor %}
+							{% endif %}
 							</ul>
 						</div>
 					</details>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -56,9 +56,9 @@ menu:
 								collection menu items
 							--> 
 							{% if item.collection_items %}
-								{% for collection-item in item.items %}
+								{% for collection-item in item.collection_items %}
 								<li {% if collection-item.badge  %} data-badge={{collection-item.badge}} {% endif %}>
-									<a href="{{ item.url_base }}/{{ collection-item.url }}" {% if page.url == item.url %} class="active" {% endif %}>{{ collection-item.title }}</a>
+									<a href="{{ item.url_base }}/{{ collection-item.url }}" {% if page.url contains collection-item.url %} class="active" {% endif %}>{{ collection-item.title }}</a>
 								</li>
 								{% endfor %}
 							<!--

--- a/collections/_getting-started/basics.md
+++ b/collections/_getting-started/basics.md
@@ -2,19 +2,7 @@
 layout: documentation
 title: Basics
 permalink: /docs/getting-started/basics
-nav-links:
-  - title: Overview
-    link: overview
-  - title: Installation
-    link: installation
-  - title: Handling requests
-    link: handling-requests
-  - title: Internal subrequests
-    link: internal-subrequests
-  - title: 1xx Informational responses
-    link: 1xx-informational-responses
-  - title: Official middleware
-    link: official-middleware
+
 ---
 
 ## Overview

--- a/collections/_getting-started/basics.md
+++ b/collections/_getting-started/basics.md
@@ -1,6 +1,6 @@
 ---
 layout: documentation
-title: Basics
+title: Introduction
 permalink: /docs/getting-started/basics
 
 ---


### PR DESCRIPTION
Added a `collection_items` property to manually sort the documentation sidebar menu items.

Removed ordering from `_config.yml`

Also removed the `nav-links` ("On this page" links) property in the front matter (`basics.md`) in favor of a little JS function that just builds it from the document's `h2` tags. (added to documentation.html in an earlier PR).

