### PR TITLE
Dark theme updates

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,5 +32,37 @@
     for (const a of externalLinks) {
       a.setAttribute('target', '_blank');
     }
+
+    const themeInputs = document.querySelectorAll('input[name="theme"]');
+    
+    for (const input of themeInputs) {
+      input.addEventListener('change', (e) => {
+        updateColorSchemePrefs(e.target.value);
+      });
+    }
+
+    function updateColorSchemePrefs(selectedtheme) {
+      let theme = null;
+
+      if(selectedtheme) {
+        theme = selectedtheme;
+      } else if (localStorage.getItem('theme')) {
+        theme = localStorage.getItem('theme');
+      }
+
+      if (theme !== null) {
+        localStorage.setItem('theme', theme);
+        document.body.dataset['theme'] = localStorage.getItem('theme');
+        document.querySelector(`input[name=theme][value=${theme}]`).checked = 'checked';
+      } else {
+          if(window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            updateColorSchemePrefs('dark');
+          }
+      }
+    }
+
+    updateColorSchemePrefs();
+    
+
   </script>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -54,10 +54,10 @@
         localStorage.setItem('theme', theme);
         document.body.dataset['theme'] = localStorage.getItem('theme');
         document.querySelector(`input[name=theme][value=${theme}]`).checked = 'checked';
-      } else {
-          if(window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
             updateColorSchemePrefs('dark');
-          }
+      } else {
+        updateColorSchemePrefs('light');
       }
     }
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -27,8 +27,8 @@
   </div>
   <div class="theme-select">
     <div class="nav-items">
-      <input type="radio" name="theme" id="theme-dark" value="dark"/>
-      <input type="radio" name="theme" id="theme-light" value="light"checked/>
+      <input type="radio" name="theme" id="theme-dark" value="dark" />
+      <input type="radio" name="theme" id="theme-light" value="light" />
       <span>theme: </span>
       <label for='theme-dark'>
         dark

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -25,4 +25,17 @@
       
       {% endfor %}
   </div>
+  <div class="theme-select">
+    <div class="nav-items">
+      <input type="radio" name="theme" id="theme-dark" value="dark"/>
+      <input type="radio" name="theme" id="theme-light" value="light"checked/>
+      <span>theme: </span>
+      <label for='theme-dark'>
+        dark
+      </label>
+      <label for='theme-light'>
+        light
+      </label>
+    </div>
+  </div>
 </div>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -546,7 +546,7 @@ blockquote {
   margin: 3rem auto 3rem 0;
   padding: 1rem;
   display: flex;
-  gap: 1rem;
+  gap: 18px;
   border-radius: 0.4ex;
   border-width: 1px;
   border-style: solid;
@@ -577,7 +577,7 @@ blockquote {
     font-family: 'Genericons';
     border-width: 0 2px 0 0;
     font-size: 1.2em;
-    padding: 0 .7ex 0 0;
+    padding: 0 16px 0 0;
     vertical-align: middle;
     color: var(--accent-color, #777);
   }
@@ -635,10 +635,11 @@ blockquote {
 
   &.help {
     &::before {
-      --accent-color: #ff4e60;
+      --accent-color: #006699;
       content: '\f457';
     }
   }
+
   &.hint {
     &::before {
       --accent-color: #ff4e60;
@@ -655,8 +656,9 @@ blockquote {
   
   &.warning {
     &::before {
-      --accent-color: #ff4e60;
-      content: '\f456';
+      --accent-color: #ff9600;
+      --accent-color: #ffaf50;
+      content: '\f414';
     } 
   }
   

--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -9,7 +9,7 @@
     & + label {
       display: none;
       padding: 0 .8em;
-      position: fixed;
+      position: sticky;
       top: 85vh;
       left: .5rem;
       z-index: 2;
@@ -224,7 +224,7 @@
   box-shadow: inset 0 0 0 1px currentColor;
 }
 
-/* Mobile styles */
+/* Mobile styles: Docs */
 @media only screen and (max-width: 1080px) {
   .docs-page-wrapper {
 
@@ -246,6 +246,23 @@
       transform: translateX(-100%);
       transition: all .2s cubic-bezier(.65,.05,.36,1);
       z-index: 1;
+      
+      .navbar-sticky-wrapper {
+        padding-bottom: 6rem;
+      }
+
+      details summary {
+        padding-left: 3rem;
+        line-height: 4rem;
+        &::after {
+          left: 1ex;
+          top: 1.3ex;
+        }
+      }
+
+      a {
+        padding: 1ex 2ex;
+      }
     }
 
     /* SIDEBAR TOGGLE SYSTEM */

--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -2,7 +2,7 @@
   width: 100%;
   height: 60px;
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-around;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -18,13 +18,14 @@
 }
 
 .navbar .nav-items {
-  flex: 1 0 auto;
-  height: 100%;
-  align-content: center;
-  display: flex;
-  flex-direction: row;
   align-items: center;
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: row;
   gap: 1ex;
+  height: 100%;  
+  max-width: 760px; // same as .inner divs, aligning the menu with the content in the page
+  padding: 0 20px;
 }
 
 .nav-item {
@@ -32,7 +33,8 @@
   height: 100%;
 }
 
-.navbar .nav-items a {
+.navbar .nav-items a,
+.navbar .nav-items label {
   color: rgba(255, 255, 255, .7);
   font-size: 1.1em;
   display: block;
@@ -73,25 +75,40 @@
   }
 }
 
-.navbar .social-links {
+.navbar .theme-select {
   flex: 0 1 auto;
   margin-right: 1rem;
-}
 
-.navbar .social-links a {
-  margin: 0 5px 0 5px;
-  color: white;
-  opacity: .5;
-}
+  input { 
+    display: none;
+    
+    &#theme-dark:checked {
+      &:checked ~ label[for='theme-dark'] {
+        color: white;
+        text-decoration-color: #46e2e4; 
+        
+        &::after{
+          border-radius: 1px!important;
+          width: 1em!important;
+          opacity: .5;
+        }
+      }
+    }
 
-.navbar .social-links a span {
-  font-size: 24px;
-  height: 24px;
-  width: 24px;
-}
+    &#theme-light:checked {
+      &:checked ~ label[for='theme-light'] {
+        color: white;
+        text-decoration-color: #46e2e4; 
+        
+        &::after{
+          border-radius: 1px!important;
+          width: 1em!important;
+          opacity: .5;
+        }
+      }
+    }
+  }
 
-.navbar .social-links a:hover {
-  opacity: .75;
 }
 
 .dropdown {
@@ -132,4 +149,16 @@
 
 .dropdown:hover .dropdown-content {
   display: block;
+}
+
+/* Mobile styles: Main navbar */
+@media only screen and (max-width: 1080px) {
+  .navbar { 
+    .theme-select span {
+      display: none;
+    }
+    .nav-items {
+      padding: 0;
+    }
+  }
 }

--- a/_sass/userprefs.scss
+++ b/_sass/userprefs.scss
@@ -34,10 +34,20 @@
     strong {
       color: black;
     }
-
+    img {
+      filter: invert(1);
+    }
   }
   
   .special.cta {
     border-bottom-color: var(--purple-800);
+  }
+
+  .note {
+    --accent-color: white;
+    &::before,
+    &::after {
+      filter: invert(1);
+    }
   }
 }

--- a/_sass/userprefs.scss
+++ b/_sass/userprefs.scss
@@ -1,5 +1,7 @@
-@media (prefers-color-scheme: dark) {
-
+body[data-theme="dark"] {
+  
+  color: #444;
+  
   .navbar, 
   footer {
     background-color: var(--purple-800);
@@ -16,9 +18,6 @@
     }
   }
 
-  body {
-    color: #444;
-  }
 
   section.wrapper:not(.special.cta), 
   #middle, 

--- a/collections/_documentation/writing-docs.md
+++ b/collections/_documentation/writing-docs.md
@@ -89,6 +89,15 @@ This paragraph indicates discussion.
 {:.note.comment}
 > This blockquotes indicates discussion.
 
+**`.note.help`**
+
+{:.note.help}
+A sign showing people where they can find help
+
+{:.note.help}
+> In case you got lost please checkout [this other document](#)
+
+
 **`.note.hint`**
 
 {:.note.hint}
@@ -114,14 +123,6 @@ Use **`.info`**  for stuff you want to point out, but differently.
 > _If any of these concepts are foreign, this documentation is **likely not** a good
 jumping off point._
 
-**`.note.good`**
-
-{:.note.good}
-**Encouraged** &ndash; Tips, best practices etc
-
-{:.note.good}
-> Please dumb at municipal waste processing plant please.
-
 **`.note.bad`**
 
 {:.note.bad}
@@ -129,6 +130,14 @@ jumping off point._
 
 {:.note.bad}
 > Not dumb here. Please do not dumb here.
+
+**`.note.good`**
+
+{:.note.good}
+**Encouraged** &ndash; Tips, best practices etc
+
+{:.note.good}
+> Please dumb at municipal waste processing plant please.
 
 **`.note.fixme`**
 


### PR DESCRIPTION
## closes: #28, #32 and #34 

### changes 
- un-inverts filter on `img`s, double negatives babyy
- Adds a dark / light theme toggle in the main nav, using (styled) radio buttons
- theme preference is stored in and read from `localStorage`
- (Always) adds a `data-theme` attribute to the `body`. Instead of using a `@media (prefers-color-scheme: dark)` selector, I'm using this attribute selector. 

The reason: you can't _set_ this `prefers-color-scheme` value, so any manual theme setting will have to rely on setting a class or other selector. These selectors can't be combined with media queries, so effectively I'd have two near identical pieces of dark theme css.

Using a little :sparkles: recursion :sparkles:, I'm now processing the browser/OS color-theme setting with the manual override to make it all work in one go :muscle: 

Luv to hear your thoughts 

### preview 
![image](https://user-images.githubusercontent.com/5741190/192999263-f3df5dc0-2c58-4608-a02f-08ba0183c12e.png)
