### PR TITLE
Sh/head metatags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,12 +2,10 @@
 	{% capture canonical %}{{ site.url }}{{ site.baseurl }}{% if site.permalink contains '.html' %}{{ page.url }}{% elsif site.permalink contains category_dir %}{{ '/' | page.url | remove:'index.html' | '/' }}{% else %}{{ page.url | remove:'index.html' | '/' }}{% endif %}{% endcapture %}
 	<meta charset="utf-8">
 	<link rel="canonical" href="{{ canonical }}" />
-	
 	{% if page.description %}
 	<meta name="description" content="{{ page.description | strip_html | truncatewords: 20 }}" />                                                                                                      
 	<meta property="og:description" content="{{ page.description | strip_html | truncatewords: 20 }}" />
 	{% endif %}
-
 	<meta itemprop="image" content="{% if page.image.url %}{{ site.baseurl }}{{ page.image.url }}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.icon }}{% endif %}" />
 	<meta property="og:image" content="{% if page.image.url %}{{ site.baseurl }}{{ page.image.url }}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.icon }}{% endif %}" />
 	<meta property="og:title" content="{{ site.title page.title }}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,18 @@
 <head>
+	{% capture canonical %}{{ site.url }}{{ site.baseurl }}{% if site.permalink contains '.html' %}{{ page.url }}{% elsif site.permalink contains category_dir %}{{ '/' | page.url | remove:'index.html' | '/' }}{% else %}{{ page.url | remove:'index.html' | '/' }}{% endif %}{% endcapture %}
 	<meta charset="utf-8">
 	<link rel="canonical" href="{{ canonical }}" />
-	<meta name="description" content="{% if page.quote %}{{ page.quote }}{% else %}{{ page.content | strip_html | truncatewords: 20 }}{% endif %}" />
-	<meta property="og:description" content="{% if page.quote %}{{ page.quote }}{% else %}{{ page.content | strip_html | truncatewords: 20 }}{% endif %}" />
+	
+	{% if page.description %}
+	<meta name="description" content="{{ page.description | strip_html | truncatewords: 20 }}" />                                                                                                      
+	<meta property="og:description" content="{{ page.description | strip_html | truncatewords: 20 }}" />
+	{% endif %}
+
 	<meta itemprop="image" content="{% if page.image.url %}{{ site.baseurl }}{{ page.image.url }}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.icon }}{% endif %}" />
 	<meta property="og:image" content="{% if page.image.url %}{{ site.baseurl }}{{ page.image.url }}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.icon }}{% endif %}" />
-	<meta property="og:title" content="{{ page.title }}" />
+	<meta property="og:title" content="{{ site.title page.title }}" />
 	<meta property="og:type" content="article" />
-	<meta property="og:url" content="{{ canonical }}" />
+	<meta property="og:url" content="{{ site.url }}{{ page.url | replace:'index.html',''}}" />
 	<meta property="og:site_name" content="{{ site.title }}" />
 	<title>{% if page.title == "Home" %}{{ site.title }} &middot; {{ site.tagline }}{% else %}{{ page.title }} &middot; {{ site.title }}{% endif %}</title>
 	<meta name="mobile-web-app-capable" content="yes">

--- a/collections/_documentation/aws-lambda.md
+++ b/collections/_documentation/aws-lambda.md
@@ -2,6 +2,7 @@
 layout: documentation
 title: AWS Lambda
 permalink: /docs/aws-lambda
+description: Run Curveball on AWS Lambda
 ---
 
 Curveball runs natively on AWS lambda, but we do recommend getting some


### PR DESCRIPTION
Resolves #36 

This changes the code to no longer put Markdown into the content but actual, raw, text.
Adds an example `description` property to the AWS Lambda documentation page, other pages should also get a description like this. 